### PR TITLE
feat: Add flexible code editing features

### DIFF
--- a/src/RoslynAsAServiceAPI/Groups/FilesGroup.cs
+++ b/src/RoslynAsAServiceAPI/Groups/FilesGroup.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace RoslynAsAServiceAPI.Groups
+{
+    public static class FilesGroup
+    {
+        public static void MapFilesApi(this IEndpointRouteBuilder app)
+        {
+            var apiGroup = app.MapGroup("/api/files")
+                .AddEndpointFilter<ApiKeyEndpointFilter>();
+
+            // Define endpoints here
+            apiGroup.MapPost("/find", FindFiles).WithTags("File System");
+            apiGroup.MapPost("/replace-text", ReplaceText).WithTags("File System");
+            apiGroup.MapPost("/insert-text", InsertText).WithTags("File System");
+            apiGroup.MapPost("/create-file", CreateFile).WithTags("File System");
+        }
+
+        private static async Task<IResult> CreateFile([FromBody] CreateFileCommand command)
+        {
+            try
+            {
+                await File.WriteAllTextAsync(command.FilePath, command.Content);
+                return Results.Ok(new { message = "File created successfully." });
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem($"Error creating file: {ex.Message}");
+            }
+        }
+
+        private static async Task<IResult> InsertText([FromBody] InsertTextCommand command)
+        {
+            if (!File.Exists(command.FilePath))
+            {
+                return Results.NotFound(new { message = "File not found.", file = command.FilePath });
+            }
+
+            try
+            {
+                var lines = (await File.ReadAllLinesAsync(command.FilePath)).ToList();
+                if (command.LineNumber < 1 || command.LineNumber > lines.Count + 1)
+                {
+                    return Results.BadRequest(new { message = "Line number is out of bounds." });
+                }
+                lines.Insert(command.LineNumber - 1, command.TextToInsert);
+                await File.WriteAllLinesAsync(command.FilePath, lines);
+                return Results.Ok(new { message = "Text inserted successfully." });
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem($"Error inserting text: {ex.Message}");
+            }
+        }
+
+        private static async Task<IResult> ReplaceText([FromBody] ReplaceTextCommand command)
+        {
+            if (!File.Exists(command.FilePath))
+            {
+                return Results.NotFound(new { message = "File not found.", file = command.FilePath });
+            }
+
+            try
+            {
+                var content = await File.ReadAllTextAsync(command.FilePath);
+                content = content.Replace(command.OldText, command.NewText);
+                await File.WriteAllTextAsync(command.FilePath, content);
+                return Results.Ok(new { message = "File updated successfully." });
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem($"Error replacing text: {ex.Message}");
+            }
+        }
+
+        private static Task<IResult> FindFiles([FromBody] FindFilesQuery query)
+        {
+            if (!Directory.Exists(query.Path))
+            {
+                return Task.FromResult(Results.NotFound(new { message = "Directory not found.", path = query.Path }));
+            }
+
+            try
+            {
+                var searchPattern = $"*.{query.Extension.TrimStart('.')}";
+                var files = Directory.GetFiles(query.Path, searchPattern, SearchOption.AllDirectories).ToList();
+                return Task.FromResult(Results.Ok(new FindFilesResponse(files)));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(Results.Problem($"Error searching for files: {ex.Message}"));
+            }
+        }
+    }
+
+    // --- DTOs ---
+    public record FindFilesQuery(string Path, string Extension);
+    public record FindFilesResponse(List<string> Files);
+    public record ReplaceTextCommand(string FilePath, string OldText, string NewText);
+    public record InsertTextCommand(string FilePath, int LineNumber, string TextToInsert);
+    public record CreateFileCommand(string FilePath, string Content);
+}

--- a/src/RoslynAsAServiceAPI/Program.cs
+++ b/src/RoslynAsAServiceAPI/Program.cs
@@ -31,6 +31,7 @@ namespace RoslynAsAServiceAPI
             app.UseAuthorization();
 
             app.MapRoslynApi();
+            app.MapFilesApi();
 
             app.Run();
         }

--- a/src/RoslynAsAServiceAPI/appsettings.json
+++ b/src/RoslynAsAServiceAPI/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiKey": "test-api-key"
 }

--- a/test.sql
+++ b/test.sql
@@ -1,0 +1,2 @@
+-- This is a test SQL file.
+SELECT * FROM Users;


### PR DESCRIPTION
This commit introduces a new set of endpoints for flexible code editing, allowing for manipulation of any text-based file, including SQL files.

Changes:
- Created a new `FilesGroup.cs` to house generic file operation endpoints.
- Implemented the following endpoints in `FilesGroup.cs`:
  - `POST /api/files/find`: Finds files with a given extension.
  - `POST /api/files/replace-text`: Replaces text in a file.
  - `POST /api/files/insert-text`: Inserts text at a specific line in a file.
  - `POST /api/files/create-file`: Creates a new file.
- Registered the new `FilesGroup` in `Program.cs`.
- Added a test API key to `appsettings.json`.

I was in the process of testing these new endpoints but encountered issues with the environment setup. I was unable to successfully test the endpoints due to problems with HTTPS redirection in the test environment. The next step would be to resolve these testing issues to verify the functionality of the new endpoints.